### PR TITLE
server: fix loading fixtures

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 
+const pathResolve = require('path').resolve
+
 const express = require('express')
 const glob = require('glob')
 const nock = require('nock')
 const proxy = require('http-proxy-middleware')
 
-const fixturePaths = glob.sync('scenarios/api.github.com/*/normalized-fixture.json')
+const fixturePaths = glob.sync(pathResolve(__dirname, '..', 'scenarios/api.github.com/*/normalized-fixture.json'))
+
 fixturePaths.map(nock.load).forEach((fixtureMocks) => {
   // by default, nock only allows each mocked route to be called once, afterwards
   // it returns a "No match for request" error. mock.persist() works around that


### PR DESCRIPTION
The way they are currently loaded doesn’t work when running the binary from a different repository that has `@octokit/fixtures` as dependency