### PR TITLE
Allow commandline arguments for external fixtures with bin/serve.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .nyc_output
 coverage
 node_modules
+*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - COMMAND=test:unit
     - COMMAND=test:integration
     - COMMAND=test:scenarios
+    - COMMAND=test:external-fixtures
     - COMMAND=test:e2e
     - COMMAND=coverage:upload
 

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -6,8 +6,25 @@ const express = require('express')
 const glob = require('glob')
 const nock = require('nock')
 const proxy = require('http-proxy-middleware')
+const yargs = require('yargs')
 
-const fixturePaths = glob.sync(pathResolve(__dirname, '..', 'scenarios/api.github.com/*/normalized-fixture.json'))
+
+const { argv } = yargs.options({
+    fixtures: {
+      type: 'string',
+      describe: 'Path glob for all test fixtures',
+      default: pathResolve(__dirname, '..', 'scenarios/api.github.com/*/normalized-fixture.json')
+    },
+    debug: {
+      type: 'string',
+      describe: 'Set logging level',
+      default: 'debug'
+    },
+  })
+  .help();
+
+const fixturePaths = glob.sync(argv.fixtures)
+fixturePaths.forEach(mock => console.log(`Fixture found ${mock}`))
 
 fixturePaths.map(nock.load).forEach((fixtureMocks) => {
   // by default, nock only allows each mocked route to be called once, afterwards
@@ -19,7 +36,7 @@ const app = express()
 app.use('/', proxy({
   target: 'https://api.github.com',
   changeOrigin: true,
-  loglevel: 'debug',
+  loglevel: argv.loglevel,
   onError (error, request, response) {
     response.writeHead(500, {
       'Content-Type': 'application/json; charset=utf-8'

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -15,9 +15,9 @@ const { argv } = yargs.options({
       describe: 'Path glob for all test fixtures',
       default: pathResolve(__dirname, '..', 'scenarios/api.github.com/*/normalized-fixture.json')
     },
-    debug: {
+    loglevel: {
       type: 'string',
-      describe: 'Set logging level',
+      describe: 'Set logging level for Express',
       default: 'debug'
     },
   })

--- a/package.json
+++ b/package.json
@@ -37,13 +37,14 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "nock": "^9.0.21",
-    "url-template": "^2.0.8"
+    "url-template": "^2.0.8",
+    "yargs": "^10.0.3"
   },
   "optionalDependencies": {
-    "express": "^4.15.4",
-    "http-proxy-middleware": "^0.17.4",
     "envalid": "^4.0.1",
+    "express": "^4.15.4",
     "glob": "^7.1.2",
+    "http-proxy-middleware": "^0.17.4",
     "json-diff": "^0.5.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:scenarios": "tap 'scenarios/**/test.js'",
     "test:node4": "node test/node-4-compatibility.js",
     "test:e2e": "test/end-to-end/server-test.sh",
+    "test:external-fixtures": "test/end-to-end/server-external-fixtures-test.sh",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {

--- a/test/end-to-end/server-external-fixtures-test.sh
+++ b/test/end-to-end/server-external-fixtures-test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+npm link .
+octokit-fixtures-server --fixtures $(pwd)/scenarios/api.github.com/get-organization/normalized-fixture.json &
+serverPid=$!
+
+sleep 3
+
+# should succeed since we're loading the get-organization fixture
+curl -H'Accept: application/vnd.github.v3+json' http://localhost:3000/orgs/octokit-fixture-org | grep -q '"login":"octokit-fixture-org"'
+returnCode1=$? # is 0 if grep could not find string above
+
+# should fail since we're not loading the repo (inverted due to grep -v)
+curl -H'Accept: application/vnd.github.v3+json' http://localhost:3000/repos/octokit-fixture-org/hello-world | grep -v -q '"full_name":"octokit-fixture-org/hello-world"'
+returnCode2=$? # is 1 if grep could not find string above
+
+kill $serverPid
+! (( $returnCode1 || $returnCode2 ))

--- a/test/end-to-end/server-external-fixtures-test.sh
+++ b/test/end-to-end/server-external-fixtures-test.sh
@@ -12,7 +12,10 @@ returnCode1=$? # is 0 if grep could not find string above
 
 # should fail since we're not loading the repo (inverted due to grep -v)
 curl -H'Accept: application/vnd.github.v3+json' http://localhost:3000/repos/octokit-fixture-org/hello-world | grep -v -q '"full_name":"octokit-fixture-org/hello-world"'
-returnCode2=$? # is 1 if grep could not find string above
+returnCode2=$? # is 0 if grep could not find string above
 
+# stop the server
 kill $serverPid
+
+# exit non-zero if any return codes are non-zero
 ! (( $returnCode1 || $returnCode2 ))


### PR DESCRIPTION
- add commandline argument for external fixtures using yargs (default remains the same)
- also add debug as a commandline flag
- log what fixtures are loaded when starting server
- add test values to be sure the argument works

RE: #71