### PR TITLE
ci: fix prettier workflow

### DIFF
--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -2,7 +2,7 @@ name: Update Prettier
 "on":
   push:
     branches:
-      - dependabot/npm_and_yarn/prettier-*
+      - renovate/prettier-*
 jobs:
   update_prettier:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "into-stream": "^6.0.0",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.3",
-    "prettier": "^2.0.1",
+    "prettier": "2.3.0",
     "proxyquire": "^2.1.0",
     "semantic-release": "^17.0.0",
     "tap": "^15.0.0",


### PR DESCRIPTION
When we switched from Dependabot to Renovate, the workflow was never updated to match the new branch name