### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
       - run: npm ci
       - run: npx semantic-release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
       - run: npm ci
       - run: npm test

--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
       - run: npm ci
       - run: "npm run lint:fix"
       - uses: gr2m/create-or-update-pull-request-action@v1.x

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
       - run: git checkout fixtures-update || true
       - run: npm ci
       - run: node bin/record --update


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
