### PR TITLE
build: correct `mkdirp` import, fix full relative import in tests, fix prettier usage

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -5,7 +5,7 @@ import { writeFile } from "fs/promises";
 import { fileURLToPath } from "url";
 
 import * as prettier from "prettier";
-import mkdirp from "mkdirp";
+import { mkdirp } from "mkdirp";
 
 async function write(fixturesPath, fixtures) {
   const path = resolve(

--- a/lib/write.js
+++ b/lib/write.js
@@ -19,7 +19,9 @@ async function write(fixturesPath, fixtures) {
   return Promise.all([
     writeFile(
       resolve(path, "normalized-fixture.json"),
-      await prettier.format(JSON.stringify(fixtures.normalized), { parser: "json" }),
+      await prettier.format(JSON.stringify(fixtures.normalized), {
+        parser: "json",
+      }),
     ),
     writeFile(
       resolve(path, "raw-fixture.json"),

--- a/lib/write.js
+++ b/lib/write.js
@@ -19,11 +19,11 @@ async function write(fixturesPath, fixtures) {
   return Promise.all([
     writeFile(
       resolve(path, "normalized-fixture.json"),
-      prettier.format(JSON.stringify(fixtures.normalized), { parser: "json" }),
+      await prettier.format(JSON.stringify(fixtures.normalized), { parser: "json" }),
     ),
     writeFile(
       resolve(path, "raw-fixture.json"),
-      prettier.format(JSON.stringify(fixtures.raw), { parser: "json" }),
+      await prettier.format(JSON.stringify(fixtures.raw), { parser: "json" }),
     ),
   ]);
 }

--- a/test/integration/smoke.test.js
+++ b/test/integration/smoke.test.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import fixtures from "../..";
+import fixtures from "../../index.js";
 import { readFileSync } from "fs";
 
 test("Accepts fixtures object as argument", async () => {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The tests would fail because the import for `mkdirp` wasn't the right one

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The import for `mkdirp` is updated and tests run

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

